### PR TITLE
Added description for SICK sensors used in Euler

### DIFF
--- a/euler_gazebo/urdf/euler_gazebo.xacro
+++ b/euler_gazebo/urdf/euler_gazebo.xacro
@@ -7,9 +7,11 @@
   <xacro:include filename="$(find euler_gazebo)/urdf/euler.gazebo.controllers.xacro"/>
   <xacro:include filename="$(find euler_gazebo)/urdf/gazebo/sick_macros.gazebo.xacro" /> 
 
-  <!-- Sensors-->
-  <sick_s300_gazebo link="front_sick_s300" topic_name="front_sick_s300" />
+  <!-- Front sensor SICK S300 -->
+  <sick_s300_gazebo link="front_sick_s300" topic_name="front_sick_s300" visualize="true" />
+  <!-- Rear sensor SICK S300 -->
   <sick_s300_gazebo link="rear_sick_s300" topic_name="rear_sick_s300" />
+  <!-- Front, high-res sensor SICK Nav350 -->
   <sick_nav350_gazebo link="sick_nav350" topic_name="sick_nav350" />
 
 

--- a/euler_gazebo/urdf/gazebo/sick_macros.gazebo.xacro
+++ b/euler_gazebo/urdf/gazebo/sick_macros.gazebo.xacro
@@ -1,12 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="sick_macros_gazebo" >
 
-  <xacro:macro name="sick_s300_gazebo" params="link topic_name">
+  <!-- Datasheet SICK S300: https://www.sick.com/media/pdf/6/46/846/dataSheet_S30B-3011GB_1057641_en.pdf -->
+  <xacro:macro name="sick_s300_gazebo" params="link topic_name visualize:=false">
 
     <gazebo reference="${link}">
       <sensor type="ray" name="${link}_sensor">
         <pose>0 0 0 0 0 0</pose>
-        <visualize>false</visualize>
+        <visualize>${visualize}</visualize>
         <update_rate>12.5</update_rate> <!-- Response time 80ms -->
         <ray>
           <scan>
@@ -33,13 +34,13 @@
     </gazebo>
   </xacro:macro>
 
-  <!-- Laser Scanner NAV350 Indoor Mid Range -->
-  <xacro:macro name="sick_nav350_gazebo" params="link topic_name">
+  <!-- Datasheet NAV350 Indoor Mid Range: https://sick-virginia.data.continum.net/media/pdf/1/41/041/dataSheet_NAV350-3232_1052928_en.pdf -->
+  <xacro:macro name="sick_nav350_gazebo" params="link topic_name visualize:=false">
 
     <gazebo reference="${link}">
       <sensor type="ray" name="${link}_sensor">
         <pose>0 0 0 0 0 0</pose>
-        <visualize>false</visualize>
+        <visualize>${visualize}</visualize>
         <update_rate>8.0</update_rate> <!-- 8Hz -->
         <ray>
           <scan>


### PR DESCRIPTION
To test:

Start the gazebo simulation. You will see the rays of the frontal SICK S300 sensor (I set the visualization of the other 2 sensors to be false to avoid wasting computation time):

roslaunch euler_support euler_gazebo.launch

Try playing by adding objects in the simulation and observing how the rays length change as they intersect the objects.