### PR TITLE
Feature/add asus xtion functionality

### DIFF
--- a/euler_gazebo/urdf/euler_gazebo.xacro
+++ b/euler_gazebo/urdf/euler_gazebo.xacro
@@ -6,13 +6,21 @@
   <xacro:include filename="$(find euler_gazebo)/urdf/euler.gazebo.components.xacro"/> 
   <xacro:include filename="$(find euler_gazebo)/urdf/euler.gazebo.controllers.xacro"/>
   <xacro:include filename="$(find euler_gazebo)/urdf/gazebo/sick_macros.gazebo.xacro" /> 
+  <xacro:include filename="$(find euler_gazebo)/urdf/gazebo/asus_xtion_macro.gazebo.xacro" /> 
 
   <!-- Front sensor SICK S300 -->
-  <sick_s300_gazebo link="front_sick_s300" topic_name="front_sick_s300" />
+  <!--<sick_s300_gazebo link="front_sick_s300" topic_name="front_sick_s300" />-->
   <!-- Rear sensor SICK S300 -->
-  <sick_s300_gazebo link="rear_sick_s300" topic_name="rear_sick_s300" />
+  <!--<sick_s300_gazebo link="rear_sick_s300" topic_name="rear_sick_s300" />-->
   <!-- Front, high-res sensor SICK Nav350 -->
-  <sick_nav350_gazebo link="sick_nav350" topic_name="sick_nav350" />
+  <!--<sick_nav350_gazebo link="sick_nav350" topic_name="sick_nav350" />-->
+
+  <!-- Asus Xtion -->
+  <asus_xtion_gazebo parent_link="asus_bodycenter" topic_name="asus" depth_frame="asus_depth_frame" />
+
+  <gazebo reference="asus_bodycenter">
+    <material>Gazebo/Black</material>
+  </gazebo>
 
 
   <gazebo reference="frame_left">

--- a/euler_gazebo/urdf/gazebo/asus_xtion_macro.gazebo.xacro
+++ b/euler_gazebo/urdf/gazebo/asus_xtion_macro.gazebo.xacro
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="asus_xtion_macro_gazebo">
+
+  <xacro:property name="M_PI" value="3.14159"/> 
+
+  <!-- ASUS Xtion PRO camera for simulation -->
+  <!-- https://www.asus.com/us/3D-Sensor/Xtion_PRO_LIVE/specifications/ -->
+  <xacro:macro name="asus_xtion_gazebo" params="parent_link topic_name depth_frame">
+
+      <gazebo reference="${parent_link}">
+        <sensor type="depth" name="${parent_link}">
+          <update_rate>30</update_rate>
+          <camera>
+            <horizontal_fov>${62.8 * M_PI/180.0}</horizontal_fov>
+            <image>
+              <format>R8G8B8</format>
+              <width>640</width>
+              <height>480</height>
+            </image>
+            <clip>
+              <near>0.8</near>
+              <far>3.5</far>
+            </clip>
+          </camera>
+          <plugin name="${parent_link}_camera_controller" filename="libgazebo_ros_openni_kinect.so">
+            <alwaysOn>true</alwaysOn>
+            <updateRate>0</updateRate>
+            <imageTopicName>${topic_name}/rgb/image_raw</imageTopicName>
+            <cameraInfoTopicName>${topic_name}/rgb/camera_info</cameraInfoTopicName>
+            <depthImageTopicName>${topic_name}/depth/image_raw</depthImageTopicName>
+            <depthImageCameraInfoTopicName>${topic_name}/depth/camera_info</depthImageCameraInfoTopicName>
+            <pointCloudTopicName>${topic_name}/depth/points</pointCloudTopicName>
+            <frameName>${depth_frame}</frameName> <!-- _depth_optical_frame -->
+            <distortion_k1>0.0</distortion_k1>
+            <distortion_k2>0.0</distortion_k2>
+            <distortion_k3>0.0</distortion_k3>
+            <distortion_t1>0.0</distortion_t1>
+            <distortion_t2>0.0</distortion_t2>
+          </plugin>
+        </sensor>
+      </gazebo>
+    </xacro:macro>
+  
+    
+
+</robot>

--- a/euler_support/config/euler_craftsman.rviz
+++ b/euler_support/config/euler_craftsman.rviz
@@ -6,6 +6,8 @@ Panels:
       Expanded:
         - /Global Options1
         - /Status1
+        - /PointCloud21
+        - /PointCloud21/Status1
       Splitter Ratio: 0.5
     Tree Height: 843
   - Class: rviz/Selection
@@ -59,6 +61,19 @@ Visualization Manager:
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
+        asus_bodycenter:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        asus_depth_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        asus_rgb_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
         base_link:
           Alpha: 1
           Show Axes: false
@@ -247,10 +262,40 @@ Visualization Manager:
       Topic: /navigation_path
       Unreliable: false
       Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.00999999978
+      Style: Flat Squares
+      Topic: /asus/depth/points
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: odom
+    Fixed Frame: base_link
     Frame Rate: 30
   Name: root
   Tools:
@@ -282,10 +327,10 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.00999999978
-      Pitch: 0.285397291
+      Pitch: 0.295397282
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 0.625399828
+      Yaw: 6.23358536
     Saved: ~
 Window Geometry:
   Displays:

--- a/euler_support/urdf/asus_xtion_pro.xacro
+++ b/euler_support/urdf/asus_xtion_pro.xacro
@@ -34,7 +34,7 @@
 
 
   <joint name="${sensor_name}_depth_joint" type="fixed">
-    <origin xyz="0.049 0 0" rpy="-1.5708 0 -1.5708" />
+    <origin xyz="0 -0.049 0" rpy="-1.5708 0 -1.5708" />
     <parent link="${sensor_name}_bodycenter" />
     <child link="${sensor_name}_depth_frame" />
   </joint>
@@ -42,7 +42,7 @@
   <link name="${sensor_name}_depth_frame" />
 
   <joint name="${sensor_name}_rgb_joint" type="fixed">
-    <origin xyz="0.022 0 0" rpy="-1.5708 0 -1.5708" />
+    <origin xyz="0 -0.022 0" rpy="-1.5708 0 -1.5708" />
     <parent link="${sensor_name}_bodycenter" />
     <child link="${sensor_name}_rgb_frame" />
   </joint>

--- a/euler_support/urdf/asus_xtion_pro.xacro
+++ b/euler_support/urdf/asus_xtion_pro.xacro
@@ -9,12 +9,12 @@
 
   <link name="${sensor_name}_bodycenter">
     <visual>
-      <origin xyz="0 0 0 " rpy="0 0 0" />
+      <origin xyz="0 0 0 " rpy="-1.5708 0 -1.5708" />
       <geometry>
         <mesh filename="package://euler_support/meshes/visual/asus_sensor.stl"/>
       </geometry>
       <material name="lt_black">
-        <color rgba="0.3 0.3 0.3 1"/>
+        <color rgba="0.1 0.1 0.1 1"/>
       </material>
     </visual>
 
@@ -34,7 +34,7 @@
 
 
   <joint name="${sensor_name}_depth_joint" type="fixed">
-    <origin xyz="0.049 0 0" rpy="0 0 0" />
+    <origin xyz="0.049 0 0" rpy="-1.5708 0 -1.5708" />
     <parent link="${sensor_name}_bodycenter" />
     <child link="${sensor_name}_depth_frame" />
   </joint>
@@ -42,7 +42,7 @@
   <link name="${sensor_name}_depth_frame" />
 
   <joint name="${sensor_name}_rgb_joint" type="fixed">
-    <origin xyz="0.022 0 0" rpy="0 0 0" />
+    <origin xyz="0.022 0 0" rpy="-1.5708 0 -1.5708" />
     <parent link="${sensor_name}_bodycenter" />
     <child link="${sensor_name}_rgb_frame" />
   </joint>

--- a/euler_support/urdf/euler_macro.xacro
+++ b/euler_support/urdf/euler_macro.xacro
@@ -10,7 +10,7 @@
 	
 	<xacro:vetex prefix="vetex_" />
 	<xacro:motoman_mh5lf prefix="motoman_" /> 
-	<!-- <xacro:asus_xtion_pro sensor_name="" off_x="0.461" off_y="0" off_z="2.103" off_rr="1.5708" off_rp="1.8849" off_ry="0"/>        -->
+	<xacro:asus_xtion_pro sensor_name="" off_x="0.461" off_y="0" off_z="2.103" off_rr="1.5708" off_rp="1.8849" off_ry="0"/>      
 	<xacro:eef prefix=""/>         
 	
 	<!--link list -->

--- a/euler_support/urdf/euler_macro.xacro
+++ b/euler_support/urdf/euler_macro.xacro
@@ -10,7 +10,7 @@
 	
 	<xacro:vetex prefix="vetex_" />
 	<xacro:motoman_mh5lf prefix="motoman_" /> 
-	<xacro:asus_xtion_pro sensor_name="" off_x="0.461" off_y="0" off_z="2.103" off_rr="1.5708" off_rp="1.8849" off_ry="0"/>      
+	<xacro:asus_xtion_pro sensor_name="asus" off_x="0.461" off_y="0" off_z="2.103" off_rr="0" off_rp="0.31" off_ry="0"/> <!-- 1.5708 1.8849-->      
 	<xacro:eef prefix=""/>         
 	
 	<!--link list -->


### PR DESCRIPTION
Added a plugin to simulate Asus Xtion depth sensor and also fixed the asus urdf to display its mesh properly as well as to align the depth and rgb frames correctly. Sensor is currently pointing down in front of the robot.

![gazebo_scene](https://user-images.githubusercontent.com/555379/34628903-a9fd7554-f22b-11e7-914e-ae16be18000e.png)
![rviz_viz](https://user-images.githubusercontent.com/555379/34628905-abe83606-f22b-11e7-882a-79075405dd15.png)
